### PR TITLE
Route 53 dns rename

### DIFF
--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -228,10 +228,13 @@
             ".",
             [
               {
+                "Ref": "AWS::Region"
+              },
+              {
                 "Ref": "AWS::StackName"
               },
               {
-                "Ref": "AWS::Region"
+                "Ref": "Environment"
               },
               {
                 "Ref": "BaseZone"
@@ -267,11 +270,15 @@
             "",
             [
               {
+                "Ref": "AWS::Region"
+              },
+              ".",
+              {
                 "Ref": "AWS::StackName"
               },
               ".",
               {
-                "Ref": "AWS::Region"
+                "Ref": "Environment"
               },
               ".",
               {


### PR DESCRIPTION
Per discussion with @gozer the naming convention for the jumphost has to be renamed to <aws region>.<stack name>.<environment>.nubis.allizom.org