### PR TITLE
No more hardcoded value

### DIFF
--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -238,7 +238,9 @@
           "Fn::Join": [
             ".",
             [
-              "jumphost",
+              {
+                "Ref": "ServiceName"
+              },
               {
                 "Ref": "Environment"
               },


### PR DESCRIPTION
Reference `ServiceName` instead of hard coding the `jumphost` value