### PR TITLE
Default nubis_user_groups default to empty

### DIFF
--- a/nubis/terraform/input.tf
+++ b/nubis/terraform/input.tf
@@ -29,4 +29,5 @@ variable nubis_sudo_groups {
 }
 
 variable nubis_user_groups {
+  default = ""
 }


### PR DESCRIPTION
Default userdata to empty we do this to ensure that if we don't set nubis_user_groups it will just default to empty and not error out