### PR TITLE
When installing fail2ban, make sure to keep firewalled in permissive mode

### DIFF
--- a/nubis/puppet/fail2ban.pp
+++ b/nubis/puppet/fail2ban.pp
@@ -5,3 +5,12 @@ service {'fail2ban':
   ensure => 'stopped',
   enable => true,
 }
+
+if $osfamily == 'RedHat' {
+  exec { 'firewalld default accept':
+    command => '/usr/bin/firewall-offline-cmd --zone=public --set-target=ACCEPT',
+    require => [
+      Package['fail2ban'],
+    ],
+  }
+}


### PR DESCRIPTION
Fixes #160 and nubisproject/nubis-base#765